### PR TITLE
Fix "Abc 123" on new PRs with multiple commits

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -34,6 +34,14 @@
         "src/inject/inject.js"
 
       ]
+    },
+    {
+        "matches": [
+            "https://bitbucket.org/*/pull-requests/new*"
+        ],
+        "js": [
+            "src/new-pr.js"
+        ]
     }
   ],
   "permissions": [

--- a/src/new-pr.js
+++ b/src/new-pr.js
@@ -1,0 +1,24 @@
+chrome.extension.sendMessage({}, response => {
+    function reformat(old) {
+        // Assumes the mis-formatted Jira issue keys are of the form `Aa 100` or `Aaa 100`.
+        let matches = old.match(/^([A-Z][a-z]{1,2}) (\d+)/i);
+    
+        // A match has 3 elements; the whole string and each of the two parenthesis.
+        if (matches.length === 3 && matches.index === 0) {
+            let [match, project, id] = matches;
+            project = project.toUpperCase();
+            return matches.input.replace(match, `${project}-${id}`);
+        }
+    }
+    
+    function process() {
+        let inputElement = document.querySelector('input#id_title');
+        let corrected = reformat(inputElement.value);
+        if (corrected) {
+            inputElement.value = corrected;
+            console.log('Bitbucket Awesomizer fixed badly formatted Jira issue key');
+        }
+    }
+    
+    setTimeout(process, 0);
+});


### PR DESCRIPTION
When creating a PR in Bitbucket from a branch with multiple commits, the PR title is auto generated from the branch.  `ABC-123-fix-the-foo-bar` becomes _Abc 123 fix the foo bar_.  However `ABC-123` is usually a reference to a Jira issue.

This new feature reformats `Abc 123` into `ABC-123` on Bitbucket PRs.
